### PR TITLE
Fix bioHSIC modulating term calculation

### DIFF
--- a/projectlib/hsic.py
+++ b/projectlib/hsic.py
@@ -53,7 +53,7 @@ def global_error(kx, ky, kz, z, gamma, sigma):
     N = alpha.shape[0] # samples in batch
     alpha_bar = jnp.sum(alpha[:-1], axis=0) / N
     kxky = grow_to(kx_bar - gamma * ky_bar, alpha.ndim + 1)
-    xi = (jnp.trace(kxky[:-1, :-1] * alpha[-1] / N) +
+    xi = (jnp.trace(kxky[:-1, :-1] * alpha[:-1] / N) +
           kxky[-1, -1] * alpha_bar) / ((N - 1) ** 2)
 
     return grow_dims(xi, before=1, after=0) # add batch dim back


### PR DESCRIPTION
I believe there is an error in bioHSIC modulating term [calculation](https://github.com/darsnack/biological-hsic/blob/main/projectlib/hsic.py#L56).
Last element of alpha contains (z_0 - z_0) difference (current input sample with itself) which is always 0, effectively constantly eliminating first summation in modulating term ξ
